### PR TITLE
* dnscrypt: maxDNSUDPPacketSize was increased to 4k

### DIFF
--- a/dnscrypt.go
+++ b/dnscrypt.go
@@ -37,7 +37,7 @@ var (
 	serverMagic         = [8]byte{0x72, 0x36, 0x66, 0x6e, 0x76, 0x57, 0x6a, 0x38}
 	minDNSPacketSize    = 12 + 5
 	maxDNSPacketSize    = 4096
-	maxDNSUDPPacketSize = 1252
+	maxDNSUDPPacketSize = 4096
 )
 
 const (


### PR DESCRIPTION
This patch should fix `TestDNSCryptTruncated` for [dnsproxy](https://github.com/AdguardTeam/dnsproxy)

Looks like TXT response is bigger than current maxDNSUDPPacketSize